### PR TITLE
Fix bug in obtaining historical information

### DIFF
--- a/eval/run_predict_os_atlas.py
+++ b/eval/run_predict_os_atlas.py
@@ -348,14 +348,15 @@ def predict(args, datasets):
                         print(f"Failed to load {episodes_path}: {e}")
                         continue
                         # Skip this file on error
-                    for episode in episodes:
+                    for index,episode in enumerate(episodes):
                         episode_history = []  # Create a separate history for each episode
-                        for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
+                        for prev_episode in episodes[:index]:
+                        #for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
                             image_path = os.path.join(episode_dir, episodes_file, f"{episodes_file}_{prev_episode['step_id']}.jpeg")
                             if not os.path.exists(image_path):
                                 image_path = image_path.replace(".jpeg", ".png")
                             if not os.path.exists(image_path):
-                                image_path = episode["image_path"]
+                                image_path = prev_episode["image_path"]
                             histroy_action = {
                                 "result_action_type": prev_episode['result_action_type'],
                                 "result_action_text": prev_episode['result_action_text'],

--- a/eval/run_predict_os_gensis.py
+++ b/eval/run_predict_os_gensis.py
@@ -329,14 +329,15 @@ def predict(args, datasets):
                         print(f"Failed to load {episodes_path}: {e}")
                         continue
                         # Skip this file on error
-                    for episode in episodes:
+                    for index,episode in enumerate(episodes):
                         episode_history = []  # Create a separate history for each episode
-                        for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
+                        for prev_episode in episodes[:index]:
+                        #for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
                             image_path = os.path.join(episode_dir, episodes_file, f"{episodes_file}_{prev_episode['step_id']}.jpeg")
                             if not os.path.exists(image_path):
                                 image_path = image_path.replace(".jpeg", ".png")
                             if not os.path.exists(image_path):
-                                image_path = episode["image_path"]
+                                image_path = prev_episode["image_path"]
                             histroy_action = {
                                 "result_action_type": prev_episode['result_action_type'],
                                 "result_action_text": prev_episode['result_action_text'],

--- a/eval/run_predict_qwen2_5VL.py
+++ b/eval/run_predict_qwen2_5VL.py
@@ -444,14 +444,15 @@ def predict(args, datasets):
                         print(f"Failed to load {episodes_path}: {e}")
                         continue
                         # Skip this file on error
-                    for episode in episodes:
+                    for index,episode in enumerate(episodes):
                         episode_history = []  # Create a separate history for each episode
-                        for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
+                        for prev_episode in episodes[:index]:
+                        #for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
                             image_path = os.path.join(episode_dir, episodes_file, f"{episodes_file}_{prev_episode['step_id']}.jpeg")
                             if not os.path.exists(image_path):
                                 image_path = image_path.replace(".jpeg", ".png")
                             if not os.path.exists(image_path):
-                                image_path = episode["image_path"]
+                                image_path = prev_episode["image_path"]
                             histroy_action = {
                                 "result_action_type": prev_episode['result_action_type'],
                                 "result_action_text": prev_episode['result_action_text'],

--- a/eval/run_predict_ui_tars.py
+++ b/eval/run_predict_ui_tars.py
@@ -407,14 +407,15 @@ def predict(args, datasets):
                         print(f"Failed to load {episodes_path}: {e}")
                         continue
                         # Skip this file on error
-                    for episode in episodes:
+                    for index,episode in enumerate(episodes):
                         episode_history = []  # Create a separate history for each episode
-                        for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
+                        for prev_episode in episodes[:index]:
+                        #for prev_episode in episodes[:episode['step_id']-1]:  # Only get history before current step
                             image_path = os.path.join(episode_dir, episodes_file, f"{episodes_file}_{prev_episode['step_id']}.jpeg")
                             if not os.path.exists(image_path):
                                 image_path = image_path.replace(".jpeg", ".png")
                             if not os.path.exists(image_path):
-                                image_path = episode["image_path"]
+                                image_path = prev_episode["image_path"]
                             histroy_action = {
                                 "result_action_type": prev_episode['result_action_type'],
                                 "result_action_text": prev_episode['result_action_text'],


### PR DESCRIPTION
首先感谢您的优秀工作！但是在测试复现ac,gui-odyssey过程中发现两个影响较大的数据处理代码bug，并自行修改后进行再次评测，较您paper报告中指标均有明显的提升


- 1. for prev_episode in episodes[:episode['step_id']-1]:
当链条数据以step_id=0开始时，历史step获取出现错误，导致只要涉及历史his输入+step_id=0开始的推理指标均需要重新评测
如当前episode step_id=0：prev_episode=episodes[:-1] 导致错误获取历史step为0至-1,err_his_step_id[0:-1],corr_his_step_id=[]
step_id=1：prev_episode=episodes[:0] 导致不存在历史step，err_his_step_id=[],corr_his_step_id=[0]
step_id=2：prev_episode=episodes[:1] 导致缺少step_id=1的历史step，err_his_step_id=[0],corr_his_step_id=[0,1]
...
- 2. if not os.path.exists(image_path)：image_path = episode["image_path"]
CAGUI数据正常；ac,gui-osyssey按照脚本解析原始数据后，均保存至tmp目录下，会触发此条代码逻辑，此时image_path应该为当前step的image_path，即外层循环prev_episode["image_path"]，并不是episode["iamge_path"]